### PR TITLE
rpuppy: add bazel rule to create helm chart tarball

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,19 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+## Packaging
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
+    ],
+    sha256 = "6b5969a7acd7b60c02f816773b06fcf32fbe8ba0c7919ccdc2df4f8fb923804a",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
 ## Golang
 
 http_archive(

--- a/apps/rpuppy/BUILD
+++ b/apps/rpuppy/BUILD
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@io_bazel_rules_docker//container:container.bzl", "container_push", "container_image")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_binary(
 	name = "rpuppy",
@@ -24,4 +25,12 @@ container_push(
    registry = "localhost:30500",
    repository = "giolekva/rpuppy-arm",
    tag = "latest",
+)
+
+pkg_tar(
+	name = "chart",
+	srcs = glob(["chart/**"]),
+	extension = "tar.gz",
+	strip_prefix = "chart",
+	package_dir = "rpuppy",
 )


### PR DESCRIPTION
If applied one will be able to package rpuppy helm chart using:
bazel build /apps/rpuppy:chart
Built tarball can be found at bazel-pcloud/bazel-out/darwin-fastbuild/bin/apps/rpuppy/ (on Darwin system)