### PR TITLE
tools: change sh to bash in install_core_services.sh

### DIFF
--- a/dev/install_core_services.sh
+++ b/dev/install_core_services.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ROOT=$(pwd)
 ROOT=${ROOT%/pcloud*}/pcloud


### PR DESCRIPTION
since `source` wasn't working on `sh`, I changed it with `bash`