### PR TITLE
welcome: init group memberships for first create

### DIFF
--- a/charts/welcome/templates/install.yaml
+++ b/charts/welcome/templates/install.yaml
@@ -111,6 +111,7 @@ spec:
         - --port=8080
         - --create-account-addr={{ .Values.createAccountAddr }}
         - --login-addr={{ .Values.loginAddr }}
+        - --memberships-init-addr={{ .Values.membershipsInitAddr }}
         volumeMounts:
         - name: ssh-key
           readOnly: true

--- a/charts/welcome/values.yaml
+++ b/charts/welcome/values.yaml
@@ -6,6 +6,7 @@ repoAddr: 192.168.0.11
 sshPrivateKey: key
 createAccountAddr: http://api.core-auth.svc.cluster.local/identities
 loginAddr: https://accounts-ui.example.com
+membershipsInitAddr: http://memberships.example.svc.cluster.local/api/ini
 ingress:
   className: pcloud-ingress-public
   domain: welcome.example.com

--- a/core/auth/memberships/main.go
+++ b/core/auth/memberships/main.go
@@ -116,6 +116,10 @@ func (s *SQLiteStore) Init(owner string, groups []string) error {
 		if _, err := tx.Exec(query, owner, g); err != nil {
 			return err
 		}
+		query = `INSERT INTO user_to_group (username, group_name) VALUES (?, ?)`
+		if _, err := tx.Exec(query, owner, g); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
 }

--- a/core/auth/memberships/store_test.go
+++ b/core/auth/memberships/store_test.go
@@ -27,6 +27,13 @@ func TestInitSuccess(t *testing.T) {
 	if len(groups) != 2 {
 		t.Fatalf("Expected two groups, got: %s", groups)
 	}
+	groups, err = store.GetGroupsUserBelongsTo("admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("Expected two groups, got: %s", groups)
+	}
 }
 
 func TestInitFailure(t *testing.T) {

--- a/core/installer/cmd/welcome.go
+++ b/core/installer/cmd/welcome.go
@@ -11,11 +11,12 @@ import (
 )
 
 var welcomeFlags struct {
-	repo              string
-	sshKey            string
-	port              int
-	createAccountAddr string
-	loginAddr         string
+	repo                string
+	sshKey              string
+	port                int
+	createAccountAddr   string
+	loginAddr           string
+	membershipsInitAddr string
 }
 
 func welcomeCmd() *cobra.Command {
@@ -53,6 +54,12 @@ func welcomeCmd() *cobra.Command {
 		"",
 		"",
 	)
+	cmd.Flags().StringVar(
+		&welcomeFlags.membershipsInitAddr,
+		"memberships-init-addr",
+		"",
+		"",
+	)
 	return cmd
 }
 
@@ -83,6 +90,7 @@ func welcomeCmdRun(cmd *cobra.Command, args []string) error {
 		nsCreator,
 		welcomeFlags.createAccountAddr,
 		welcomeFlags.loginAddr,
+		welcomeFlags.membershipsInitAddr,
 	)
 	s.Start()
 	return nil

--- a/core/installer/values-tmpl/core-auth.cue
+++ b/core/installer/values-tmpl/core-auth.cue
@@ -230,6 +230,8 @@ helm: {
 							allowed_return_urls: [
 								"https://*.\(global.domain)/",
 								"https://*.\(global.privateDomain)",
+								"http://*.\(global.domain)/", // TODO(gio): configure ingress nginx private to autoredirect
+								"http://*.\(global.privateDomain)",
 						    ]
 							methods: {
 								password: {

--- a/core/installer/values-tmpl/memberships.cue
+++ b/core/installer/values-tmpl/memberships.cue
@@ -1,4 +1,6 @@
-input: {}
+input: {
+	authGroups: string
+}
 
 _subdomain: "memberships"
 _domain: "\(_subdomain).\(global.privateDomain)"
@@ -15,7 +17,7 @@ _ingressWithAuthProxy: _IngressWithAuthProxy & {
 	inp: {
 		auth: {
 			enabled: true
-			groups: "" // TODO(gio): set admin
+			groups: input.authGroups
 		}
 		network: networks.private
 		subdomain: _subdomain

--- a/core/installer/values-tmpl/welcome.cue
+++ b/core/installer/values-tmpl/welcome.cue
@@ -5,8 +5,6 @@ import (
 input: {
 	repoAddr: string
 	sshPrivateKey: string
-	createAccountAddr: string
-	loginAddr: string
 }
 
 name: "welcome"
@@ -40,6 +38,7 @@ helm: {
 			sshPrivateKey: base64.Encode(null, input.sshPrivateKey)
 			createAccountAddr: "http://api.\(global.namespacePrefix)core-auth.svc.cluster.local/identities"
 			loginAddr: "https://accounts-ui.\(global.domain)"
+			membershipsInitAddr: "http://memberships.\(global.namespacePrefix)core-auth-memberships.svc.cluster.local/api/init"
 			ingress: {
 				className: _ingressPublic
 				domain: "welcome.\(global.domain)"

--- a/core/installer/welcome/welcome.go
+++ b/core/installer/welcome/welcome.go
@@ -52,13 +52,13 @@ func NewServer(
 func (s *Server) Start() {
 	r := mux.NewRouter()
 	r.PathPrefix("/static/").Handler(http.FileServer(http.FS(staticAssets)))
-	r.Path("/").Methods("POST").HandlerFunc(s.createAdminAccount)
-	r.Path("/").Methods("GET").HandlerFunc(s.createAdminAccountForm)
+	r.Path("/").Methods("POST").HandlerFunc(s.createAccount)
+	r.Path("/").Methods("GET").HandlerFunc(s.createAccountForm)
 	http.Handle("/", r)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", s.port), nil))
 }
 
-func (s *Server) createAdminAccountForm(w http.ResponseWriter, r *http.Request) {
+func (s *Server) createAccountForm(w http.ResponseWriter, r *http.Request) {
 	renderRegistrationForm(w, formData{})
 }
 
@@ -150,7 +150,7 @@ func renderRegistrationSuccess(w http.ResponseWriter, loginAddr string) {
 	}
 }
 
-func (s *Server) createAdminAccount(w http.ResponseWriter, r *http.Request) {
+func (s *Server) createAccount(w http.ResponseWriter, r *http.Request) {
 	req, err := extractReq(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/core/installer/welcome/welcome.go
+++ b/core/installer/welcome/welcome.go
@@ -26,11 +26,12 @@ var successHtml []byte
 var staticAssets embed.FS
 
 type Server struct {
-	port              int
-	repo              installer.RepoIO
-	nsCreator         installer.NamespaceCreator
-	createAccountAddr string
-	loginAddr         string
+	port                int
+	repo                installer.RepoIO
+	nsCreator           installer.NamespaceCreator
+	createAccountAddr   string
+	loginAddr           string
+	membershipsInitAddr string
 }
 
 func NewServer(
@@ -39,6 +40,7 @@ func NewServer(
 	nsCreator installer.NamespaceCreator,
 	createAccountAddr string,
 	loginAddr string,
+	membershipsInitAddr string,
 ) *Server {
 	return &Server{
 		port,
@@ -46,6 +48,7 @@ func NewServer(
 		nsCreator,
 		createAccountAddr,
 		loginAddr,
+		membershipsInitAddr,
 	}
 }
 
@@ -197,6 +200,10 @@ func (s *Server) createAccount(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if err := s.initMemberships(req.Username); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	{
 		config, err := s.repo.ReadConfig()
 		if err != nil {
@@ -233,4 +240,41 @@ func (s *Server) createAccount(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	renderRegistrationSuccess(w, s.loginAddr)
+}
+
+type firstaccount struct {
+	Created bool     `json:"created"`
+	Groups  []string `json:"groups"`
+}
+
+type initRequest struct {
+	Owner  string   `json:"owner"`
+	Groups []string `json:"groups"`
+}
+
+func (s *Server) initMemberships(username string) error {
+	inp, err := s.repo.Reader("first-account.yaml")
+	if err != nil {
+		return err
+	}
+	var fa firstaccount
+	if err := installer.ReadYaml(inp, &fa); err != nil {
+		return err
+	}
+	if fa.Created {
+		return nil
+	}
+	req := initRequest{username, fa.Groups}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(req); err != nil {
+		return err
+	}
+	if _, err = http.Post(s.membershipsInitAddr, "applications/json", &buf); err != nil {
+		return err
+	}
+	fa.Created = true
+	if err := s.repo.WriteYaml("first-account.yaml", fa); err != nil {
+		return err
+	}
+	return s.repo.CommitAndPush("initialized groups for first account")
 }


### PR DESCRIPTION
closes #108

Uses `first-account.yaml` file as the configuration for the first user, which lists group to auto create.